### PR TITLE
Update pylint: python versions, install dependencies

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint
-    - name: Analysing the code with pylint
+        pip install -e '.[test]'
+    - name: Run pylint
       run: |
-        pylint $(git ls-files '*.py')
+        pylint pbcr


### PR DESCRIPTION
Pylint will be sad when it can't import requests.

Also, let's not use 3.9, it doesn't support the `A | B` type syntax