### PR TITLE
Fix filestorage unittests

### DIFF
--- a/pbcr/tests/test_filestorage.py
+++ b/pbcr/tests/test_filestorage.py
@@ -1,17 +1,19 @@
 """File storage tests"""
+from pathlib import Path
+
 from pbcr.storage import FileImageStorage
 
 
 def test_make_filestorage(tmpdir):
     """make_storage creates a FileStorage with an existing dir structure"""
-    target = tmpdir / 'pbcr'
+    target = Path(tmpdir) / 'pbcr'
     assert not target.exists()
     storage = FileImageStorage.create(target)
     assert isinstance(storage, FileImageStorage)
-    assert target.isdir()
+    assert target.is_dir()
 
 
 def test_no_images(tmpdir):
     """An empty storage returns no images"""
-    storage = FileImageStorage(tmpdir)
+    storage = FileImageStorage(Path(tmpdir))
     assert not storage.list_images()

--- a/pbcr/tests/test_filestorage.py
+++ b/pbcr/tests/test_filestorage.py
@@ -4,16 +4,16 @@ from pathlib import Path
 from pbcr.storage import FileImageStorage
 
 
-def test_make_filestorage(tmpdir):
+def test_make_filestorage(tmp_path):
     """make_storage creates a FileStorage with an existing dir structure"""
-    target = Path(tmpdir) / 'pbcr'
+    target = tmp_path / 'pbcr'
     assert not target.exists()
     storage = FileImageStorage.create(target)
     assert isinstance(storage, FileImageStorage)
     assert target.is_dir()
 
 
-def test_no_images(tmpdir):
+def test_no_images(tmp_path):
     """An empty storage returns no images"""
-    storage = FileImageStorage(Path(tmpdir))
+    storage = FileImageStorage(tmp_path / 'pbcr')
     assert not storage.list_images()

--- a/pbcr/tests/test_filestorage.py
+++ b/pbcr/tests/test_filestorage.py
@@ -1,6 +1,4 @@
 """File storage tests"""
-from pathlib import Path
-
 from pbcr.storage import FileImageStorage
 
 


### PR DESCRIPTION
This fixes the unittests in test_filestorage.
This is because pytest's tmpdir is a LocalPath and is not exactly
compatible with pathlib's Path. So we can't use Path methods on it, we
need to make it into a Path :)
