### PR TITLE
Use big-endianness for network checksum

### DIFF
--- a/pbcr/networking/ip.py
+++ b/pbcr/networking/ip.py
@@ -42,8 +42,8 @@ class IPInfo:
         """Parse an IP header"""
         ihl = (data[0] & 0x0F) * 4
         cksum = checksum(data[:ihl])
-        if cksum != 0 and cksum != 0xffff:
-            raise ValueError("Invalid checksum: %s" % hex(cksum))
+        if cksum not in (0, 0xffff):
+            raise ValueError(f"Invalid checksum: {hex(cksum)}")
         hdr = cls(
             src=bytes(data[12:16]),
             dst=bytes(data[16:20]),

--- a/pbcr/networking/ip.py
+++ b/pbcr/networking/ip.py
@@ -34,15 +34,16 @@ class IPInfo:
             *self.dst,
         ])
         chck = checksum(iph)
-        iph[10:12] = int.to_bytes(chck, 2, "little")
+        iph[10:12] = int.to_bytes(chck, 2, "big")
         return iph
 
     @classmethod
     def parse(cls, data: bytearray) -> tuple[t.Self, bytearray]:
         """Parse an IP header"""
         ihl = (data[0] & 0x0F) * 4
-        if checksum(data[:ihl]) != 0:
-            raise ValueError("Invalid checksum")
+        cksum = checksum(data[:ihl])
+        if cksum != 0 and cksum != 0xffff:
+            raise ValueError("Invalid checksum: %s" % hex(cksum))
         hdr = cls(
             src=bytes(data[12:16]),
             dst=bytes(data[16:20]),

--- a/pbcr/networking/tcp.py
+++ b/pbcr/networking/tcp.py
@@ -81,7 +81,7 @@ class TCPInfo:
             *int.to_bytes(len(tcph), 2, "big"),
         ])
         chck = checksum(pseudo_iph + tcph)
-        tcph[16:18] = int.to_bytes(chck, 2, "little")
+        tcph[16:18] = int.to_bytes(chck, 2, "big")
 
         return tcph
 

--- a/pbcr/networking/utils.py
+++ b/pbcr/networking/utils.py
@@ -1,7 +1,5 @@
 """Utility functions for the IP stack"""
 
-import array
-
 
 def checksum(data: bytes) -> int:
     """Compute an IP checksum"""
@@ -9,7 +7,15 @@ def checksum(data: bytes) -> int:
     # pylint: disable=invalid-name
     if len(data) % 2:
         data += b'\0'
-    s = sum(array.array('H', data))
+
+    s = 0
+    # Sum 16-bit words
+    for i in range(0, len(data), 2):
+        word = (data[i] << 8) + data[i+1]
+        s += word
+
+    # Fold carries
     s = (s >> 16) + (s & 0xffff)
     s += s >> 16
+
     return ~s & 0xffff


### PR DESCRIPTION
This is supposed to be big-endian, but python array's H was little
endian.
